### PR TITLE
Fix bootloop by adding permission to whitelist

### DIFF
--- a/GmsCore/privapp-permissions-com.google.android.gms.xml
+++ b/GmsCore/privapp-permissions-com.google.android.gms.xml
@@ -13,5 +13,6 @@
         <permission name="android.permission.NETWORK_SCAN"/>
         <permission name="android.permission.UPDATE_DEVICE_STATS"/>
         <permission name="android.permission.WATCH_APPOPS"/>
+        <permission name="android.permission.START_ACTIVITIES_FROM_BACKGROUND"/>
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
In microG v0.3.1 permission "android.permission.START_ACTIVITIES_FROM_BACKGROUND" was added but it must be in whitelist for OS to boot (unless microg update was installed by user)